### PR TITLE
Fix issue #62 API call counts for twitter

### DIFF
--- a/src/session/twitter/interface.py
+++ b/src/session/twitter/interface.py
@@ -321,13 +321,12 @@ class TwitterInterface (BuffersInterface, HotkeyInterface, MetaInterface):
 
   self.session.register_buffer(_("Blocked Users"), buffers.Blocked, prelaunch_message=_("Loading blocked users."))
 
- '''
+ 
  def GetRateLimitStatus(self):
   """Reports the number of calls you can make to twitter  as well as how long you have until they reset."""
 
   output.speak(_("Checking current API call count..."), True)
   call_threaded(self.session.remaining_api_calls)
-'''
 
  @buffer_defaults
  def DeviceNotifications(self, buffer=None, index=None):

--- a/src/session/twitter/twitter.py
+++ b/src/session/twitter/twitter.py
@@ -408,9 +408,11 @@ class Twitter (Buffers, Login, Hotkey, SpeechRecognition, WebService):
   return val
 
  def remaining_api_calls(self):
-  hits = self.api_call('rate_limit_status', _("Retrieving API calls"), report_success=False)
-  resetTime = misc.SecondsToString(hits['reset_time_in_seconds'] - round(time.time()))
-  output.speak(_("You have %s API calls left.  They will reset to %d calls in %s.") % (hits['remaining_hits'], hits['hourly_limit'], resetTime), True)
+    limit = int(self.api_call('get_lastfunction_header', _("Retrieving API calls"), report_success=False, header='x-rate-limit-limit'))
+    remaining = self.api_call('get_lastfunction_header', _("Retrieving API calls"), report_success=False, header='x-rate-limit-remaining')
+    resets_in = int(self.api_call('get_lastfunction_header', _("Retrieving API calls"), report_success=False, header='x-rate-limit-reset'))
+    resetTime = misc.SecondsToString(resets_in - round(time.time()))
+    output.speak(_("You have %s API calls left.  They will reset to %d calls in %s.") % (remaining, limit, resetTime), True)
 
  def favorite_tweet(self, buffer=None, index=None):
   twitter_id = buffer[index]['id']


### PR DESCRIPTION
The Twython library seems to suggest that now it no longer has a rate_limit function
(or whatever was being used), and now these things are retrieved using
get_lastfunction_header, with the appropriate header to retrieve the value.
Possibly due to upstream Twitter API changes?