### PR TITLE
Make TheQube buildable with latest version of Python.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -10,11 +10,11 @@ h2. Running TheQube from source
 
 This document describes how to run TheQube from source and how to build a binary version.
 
-h3. Dependencies.
+h3. Dependencies
 
-To be able to build TheQube you need to install a few programs first. Most of them are included in the dependencies directory in the root of this repo. The only exception is Python. Download and install "Python 2.7 32-bit":https://www.python.org/downloads/. Be sure to add Python directory to your path during install.
+To be able to build TheQube you need to install a few programs first. Most of them are included in the dependencies directory in the root of this repo. The only exception is Python. Download and install "Python 2.7 32-bit":https://www.python.org/downloads/. Be sure to add Python directory to your path during installation.
 
-h4. Dependencies included in the dependencies directory.
+h4. Dependencies included in the dependencies directory
 
 * "Durus":https://www.mems-exchange.org/software/ (version 3.9)
 * "Python Imaging Librarry":http://www.pythonware.com/products/pil/ (version 1.1.7)
@@ -25,7 +25,7 @@ h4. Dependencies included in the dependencies directory.
 
 h4. Dependencies installed with pip
 
-The rest of the needed packages could be installed with Python package manager called pip. Before using it is a good idea to update to the latest version with the following two commands:
+The rest of the needed packages could be installed with Python package manager called pip. Before using it is a good idea to update pip to the latest version with the following two commands:
 
 bc. python -m pip install --upgrade pip
 python -m pip install --upgrade setuptools
@@ -36,15 +36,15 @@ bc. python -m pip install -r requirements.txt
 
 h3. Running TheQube
 
-When all above packages are installed you can finally start TheQube. Move to the src directory of this repo and execute
+When all above packages are installed you can finally start TheQube. Move to the src directory of this repo and execute:
 
 bc. python main.pyw
-alternatively you can start TheQube by simply pressing enter on the main.pyw file as long as Pythonw is associated with .pyw files.
+
+Alternatively you can start TheQube by simply pressing enter on the main.pyw file as long as Pythonw is associated with .pyw files.
 
 h3. Building a binary version
 
-A binary version doesn't need Python and other dependencies to run. To build it you need to install py2exe included in the dependencies
-directory and two more packages with pip by executing the following commands:
+A binary version doesn't need Python and other dependencies to run. To build it you need to install py2exe included in the dependencies directory and two more packages with pip by executing the following commands:
 
 bc. python -m pip install packaging
 python -m pip install appdirs

--- a/README.textile
+++ b/README.textile
@@ -1,7 +1,56 @@
-h2. Welcome to TheQube
+h1. Welcome to TheQube
 
 TheQube is an accessible social networking client developed mainly for the blind and visually impaired users.
 © Original idea and code by "Christopher Toth":http://q-continuum.net/
 © Main fork implementation and various new features and bugfixes by "Quartizer projects":http://quartzprojects.co.uk/
 © Currently developed and maintained by "TheQube developers team":http://theqube.oire.org/.
 Distributed under an "MIT license":http://choosealicense.com/licenses/mit/.
+
+h2. Running TheQube from source
+
+This document describes how to run TheQube from source and how to build a binary version.
+
+h3. Dependencies.
+
+To be able to build TheQube you need to install a few programs first. Most of them are included in the dependencies directory in the root of this repo. The only exception is Python. Download and install "Python 2.7 32-bit":https://www.python.org/downloads/. Be sure to add Python directory to your path during install.
+
+h4. Dependencies included in the dependencies directory.
+
+* "Durus":https://www.mems-exchange.org/software/ (version 3.9)
+* "Python Imaging Librarry":http://www.pythonware.com/products/pil/ (version 1.1.7)
+* "py2exe":http://www.py2exe.org/ (version 0.6.9) (required only if you want to build executable version of TheQube)
+* "PycURL":http://pycurl.io/ (version 7.19.0)
+* "pywin32":https://github.com/mhammond/pywin32 (version 214)
+* "wxPython":https://wxpython.org/ (version 2.9.1.1)
+
+h4. Dependencies installed with pip
+
+The rest of the needed packages could be installed with Python package manager called pip. Before using it is a good idea to update to the latest version with the following two commands:
+
+bc. python -m pip install --upgrade pip
+python -m pip install --upgrade setuptools
+
+To make installation easier all required packages are listed in the text file called requirements.txt. To install them move to the root directory of this repo, make sure that Python and git are in your path and execute the following command:
+
+bc. python -m pip install -r requirements.txt
+
+h3. Running TheQube
+
+When all above packages are installed you can finally start TheQube. Move to the src directory of this repo and execute
+
+bc. python main.pyw
+alternatively you can start TheQube by simply pressing enter on the main.pyw file as long as Pythonw is associated with .pyw files.
+
+h3. Building a binary version
+
+A binary version doesn't need Python and other dependencies to run. To build it you need to install py2exe included in the dependencies
+directory and two more packages with pip by executing the following commands:
+
+bc. python -m pip install packaging
+python -m pip install appdirs
+
+after that from the src directory execute:
+
+bc. python setup.py py2exe
+
+You will find the binaries in the dist directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ innosetup
 oauth2>=1.0.2
 oauthlib>=0.4.2
 pydispatcher
-twython==3.1.0
+git+https://github.com/ryanmcgrath/twython/

--- a/src/setup.py
+++ b/src/setup.py
@@ -82,6 +82,7 @@ if __name__ == '__main__':
   data_files = get_datafiles(),
   options = {
    'py2exe': {
+    'packages': ['packaging', 'appdirs'],
     'compressed': False,
     'dll_excludes': ['w9xpopen.exe', 'MSVCP90.dll', 'mswsock.dll', 'powrprof.dll', 'MPR.dll', 'MSVCR100.dll', 'mfc90.dll', 'MSVFW32.dll', 'AVIFIL32.dll', 'AVICAP32.dll', 'ADVAPI32.dll', 'CRYPT32.dll', 'WLDAP32.dll'],
     'optimize': 1,


### PR DESCRIPTION
Fixes #65  hopefully for good this time.
## Description of the problem
For a long time TheQube required very ancient version of Python for building an executable. The readme also lacked build instructions.
## What this PR does
- The Python 2.7.9 is removed from the dependencies directory - it is no longer needed see below.
- two packages are added to the setup script to make py2exe build process work with more recent version of setuptools.
- Readme now contains build instructions.
- The requirements file now has Windows line endings (it is a Windows only project) and installs latest version of Twython from Git which is a first step towards fixing #76.
## Testing performed.
Created binary version of TheQube using build process described in the readme with Python 2.7.16.
